### PR TITLE
Add "definingClass" property on CHBlock

### DIFF
--- a/src/Champollion/CHBlock.class.st
+++ b/src/Champollion/CHBlock.class.st
@@ -3,7 +3,8 @@ Class {
 	#superclass : #Object,
 	#instVars : [
 		'code',
-		'definingContext'
+		'definingContext',
+		'interpreter'
 	],
 	#category : #'Champollion-Core'
 }
@@ -19,6 +20,12 @@ CHBlock >> code: aRBBlockNode [
 ]
 
 { #category : #accessing }
+CHBlock >> definingClass [
+
+	^ code methodNode propertyAt: #definingClass
+]
+
+{ #category : #accessing }
 CHBlock >> definingContext [
 	^ definingContext
 ]
@@ -30,19 +37,43 @@ CHBlock >> definingContext: aContext [
 ]
 
 { #category : #accessing }
+CHBlock >> interpreter [
+	^ interpreter 
+]
+
+{ #category : #accessing }
+CHBlock >> interpreter: anInterpreter [
+
+	interpreter := anInterpreter
+]
+
+{ #category : #accessing }
 CHBlock >> value [
+
 	<primitive: 201>
-  "If the fallback code executes it means that block evaluation failed.
-  Return nil for now in such case."
-  ^ nil
+	
+	| result |
+	interpreter pushNewFrame.
+	interpreter receiver: self.
+	interpreter tempAt: #__method put: code.
+	code propertyAt: #definingClass put: self definingClass. 
+	result := interpreter primitiveBlockValue.
+	interpreter popFrame.
+	^ result 
 ]
 
 { #category : #accessing }
 CHBlock >> value: anArg [
-	"Activate the receiver, creating a closure activation (MethodContext)
-	 whose closure is the receiver and whose caller is the sender of this message.
-	 Supply the argument and copied values to the activation as its arguments and copied temps.
-	 Primitive. Optional (but you're going to want this for performance)."	 
+
 	<primitive: 202>
-	^ nil
+	
+	| result |
+	interpreter pushNewFrame.
+	
+	interpreter receiver: self.
+	interpreter tempAt: #__method put: code. 
+	code propertyAt: #definingClass put: self definingClass. 
+	result := interpreter primitiveBlockValueWith.
+	interpreter popFrame.
+	^ result
 ]

--- a/src/Champollion/CHInterpretable.class.st
+++ b/src/Champollion/CHInterpretable.class.st
@@ -148,6 +148,18 @@ CHInterpretable >> methodWithGuard [
 ]
 
 { #category : #'as yet unclassified' }
+CHInterpretable >> methodWithIfTrueGuard [
+  nil = nil ifTrue: [ ^ 42 ].
+  ^ self doSomethingExpensive
+]
+
+{ #category : #'as yet unclassified' }
+CHInterpretable >> methodWithNilGuard [
+  nil ifNil: [ ^ 42 ].
+  ^ self doSomethingExpensive
+]
+
+{ #category : #'as yet unclassified' }
 CHInterpretable >> next [
   | next |
   "Implement a stream as an increment in terms of Peano axioms.

--- a/src/Champollion/CHInterpreter.class.st
+++ b/src/Champollion/CHInterpreter.class.st
@@ -461,11 +461,13 @@ CHInterpreter >> visitAssignmentNode: anAssignmentNode [
 ]
 
 { #category : #visiting }
-CHInterpreter >> visitBlockNode: aRBBlockNode [ 
+CHInterpreter >> visitBlockNode: aRBBlockNode [
+
 	^ CHBlock new
-		code: aRBBlockNode;
-		definingContext: self topFrame;
-		yourself
+		  code: aRBBlockNode;
+		  definingContext: self topFrame;
+		  interpreter: self;
+		  yourself
 ]
 
 { #category : #visiting }

--- a/src/Champollion/CHInterpreterTest.class.st
+++ b/src/Champollion/CHInterpreterTest.class.st
@@ -133,6 +133,22 @@ CHInterpreterTest >> testBlock [
 ]
 
 { #category : #tests }
+CHInterpreterTest >> testBlockDefiningClass [
+	
+	| methodAST originalBlock chBlock interp |
+	interp := CHInterpreter new.
+	
+	methodAST := interp lookup: #buildBlock  fromClass: CHInterpretable.	
+	originalBlock := (methodAST statements at: 1) value.
+	
+	interp pushNewFrame.
+	chBlock := interp visitNode: originalBlock.
+	
+	self assert: chBlock definingClass equals: CHInterpretable.
+
+]
+
+{ #category : #tests }
 CHInterpreterTest >> testBlockTemporaryRead [
 	self
     assert: (self executeSelector: #blockTemporary)
@@ -177,6 +193,12 @@ CHInterpreterTest >> testFailingPrimitive [
 	self
       assert: (self executeSelector: #callingFailingPrimitive)
       equals: 'failure'
+]
+
+{ #category : #tests }
+CHInterpreterTest >> testIfNilNonlocalReturn [
+
+	self assert: (self executeSelector: #methodWithIfTrueGuard) equals: 42
 ]
 
 { #category : #tests }


### PR DESCRIPTION
This property is important and mandatory for the execution of fallback code in case the primitive doesn't execute properly (e.g: executed by the PharoVM instead of CHIntepreter, this situation happens when object are shared between Pharo and Champollion).

Sorry for the delay, it took me time to understand the internal mecanic of champollion to be able to write a test about this.